### PR TITLE
torch python module is now ported as a .NET static class 

### DIFF
--- a/src/Torch/torch.module.gen.cs
+++ b/src/Torch/torch.module.gen.cs
@@ -13,7 +13,7 @@ using Numpy.Models;
 
 namespace Torch
 {
-    public partial class torch
+    public static partial class torch
     {
         
         public static PyObject self => _lazy_self.Value;


### PR DESCRIPTION
As per title. this updates the following downstream Torch.NET files:
- `src\Torch\torch.module.gen.cs`

More info in:
https://github.com/SciSharp/CodeMinion/pull/8